### PR TITLE
Update inverter.h

### DIFF
--- a/sources/inverter-cli/inverter.h
+++ b/sources/inverter-cli/inverter.h
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <thread>
 #include <mutex>
+#include <string>
 
 using namespace std;
 


### PR DESCRIPTION
In Homeassistant OS I needed this line to get it working.

Log without this line:

"#13 3.365 /opt/inverter-cli/inverter.h:16:15: error: field ‘device’ has incomplete type ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’}

#13 3.365 16 | std::string device;

#13 3.365 | ^~~~~~

#13 3.367 In file included from /usr/include/c++/14/iosfwd:41,

#13 3.367 from /usr/include/c++/14/bits/std_thread.h:38,

#13 3.367 from /usr/include/c++/14/thread:45,

#13 3.367 from /opt/inverter-cli/inverter.h:5:

#13 3.367 /usr/include/c++/14/bits/stringfwd.h:72:11: note: declaration of ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}

#13 3.367 72 | class basic_string;

#13 3.367 | ^~~~~~~~~~~~

#13 3.369 /opt/inverter-cli/inverter.cpp:12:34: error: ‘devicename’ has incomplete type

#13 3.369 12 | cInverter::cInverter(std::string devicename) {

#13 3.369 | ~~~~~~~~~~~~^~~~~~~~~~

#13 3.369 /usr/include/c++/14/bits/stringfwd.h:72:11: note: declaration of ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}

#13 3.369 72 | class basic_string;

#13 3.369 | ^~~~~~~~~~~~

#13 3.369 /opt/inverter-cli/inverter.cpp: In member function ‘std::string* cInverter::GetQpigsStatus()’:

#13 3.369 /opt/inverter-cli/inverter.cpp:22:38: error: invalid use of incomplete type ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}

#13 3.369 22 | string *result = new string(status1);

#13 3.369 | ^

#13 3.369 /usr/include/c++/14/bits/stringfwd.h:72:11: note: declaration of ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}

#13 3.369 72 | class basic_string;

#13 3.369 | ^~~~~~~~~~~~

#13 3.370 /opt/inverter-cli/inverter.cpp: In member function ‘std::string* cInverter::GetQpiriStatus()’:

#13 3.370 /opt/inverter-cli/inverter.cpp:29:38: error: invalid use of incomplete type ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}

#13 3.370 29 | string *result = new string(status2);

#13 3.370 | ^

#13 3.370 /usr/include/c++/14/bits/stringfwd.h:72:11: note: declaration of ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}

#13 3.370 72 | class basic_string;

#13 3.370 | ^~~~~~~~~~~~

#13 3.370 /opt/inverter-cli/inverter.cpp: In member function ‘std::string* cInverter::GetWarnings()’:

#13 3.370 /opt/inverter-cli/inverter.cpp:36:39: error: invalid use of incomplete type ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}

#13 3.370 36 | string *result = new string(warnings);

#13 3.370 | ^

#13 3.370 /usr/include/c++/14/bits/stringfwd.h:72:11: note: declaration of ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}

#13 3.370 72 | class basic_string;

#13 3.370 | ^~~~~~~~~~~~

#13 3.371 /opt/inverter-cli/inverter.cpp: In member function ‘bool cInverter::query(const char*)’:

#13 3.371 /opt/inverter-cli/inverter.cpp:154:28: warning: pointer of type ‘void *’ used in arithmetic [-Wpointer-arith]

#13 3.371 154 | n = read(fd, (void*)buf+i, 120 - i);

#13 3.371 | ~~~~~~~~~~^~

#13 3.373 /opt/inverter-cli/inverter.cpp: At global scope:

#13 3.373 /opt/inverter-cli/inverter.cpp:248:41: error: ‘cmd’ has incomplete type

#13 3.373 248 | void cInverter::ExecuteCmd(const string cmd) {

#13 3.373 | ~~~~~~~~~~~~~^~~

#13 3.373 /usr/include/c++/14/bits/stringfwd.h:72:11: note: declaration of ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}

#13 3.373 72 | class basic_string;

#13 3.373 | ^~~~~~~~~~~~

#13 3.425 make[2]: *** [CMakeFiles/inverter_poller.dir/build.make:93: CMakeFiles/inverter_poller.dir/inverter.cpp.o] Error 1

#13 3.425 make[1]: *** [CMakeFiles/Makefile2:87: CMakeFiles/inverter_poller.dir/all] Error 2

#13 3.426 make: *** [Makefile:91: all] Error 2

#13 ERROR: process "/bin/bash -o pipefail -c cd /opt/inverter-cli && mkdir bin && cmake . && make && mv inverter_poller bin/" did not complete successfully: exit code: 2

------

> [9/9] RUN cd /opt/inverter-cli && mkdir bin && cmake . && make && mv inverter_poller bin/:

3.373 /opt/inverter-cli/inverter.cpp: At global scope:

3.373 /opt/inverter-cli/inverter.cpp:248:41: error: ‘cmd’ has incomplete type

3.373 248 | void cInverter::ExecuteCmd(const string cmd) {

3.373 | ~~~~~~~~~~~~~^~~

3.373 /usr/include/c++/14/bits/stringfwd.h:72:11: note: declaration of ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}

3.373 72 | class basic_string;

3.373 | ^~~~~~~~~~~~

3.425 make[2]: *** [CMakeFiles/inverter_poller.dir/build.make:93: CMakeFiles/inverter_poller.dir/inverter.cpp.o] Error 1

3.425 make[1]: *** [CMakeFiles/Makefile2:87: CMakeFiles/inverter_poller.dir/all] Error 2

3.426 make: *** [Makefile:91: all] Error 2

------

1 warning found (use docker --debug to expand):

- InvalidDefaultArgInFrom: Default value for ARG ${BUILD_FROM} results in empty or invalid base image name (line 2)

Dockerfile:41

--------------------

40 | # Build the inverter CLI

41 | >>> RUN cd /opt/inverter-cli && \

42 | >>> mkdir bin && \

43 | >>> cmake . && \

44 | >>> make && \

45 | >>> mv inverter_poller bin/

46 |

--------------------

ERROR: failed to build: failed to solve: process "/bin/bash -o pipefail -c cd /opt/inverter-cli && mkdir bin && cmake . && make && mv inverter_poller bin/" did not complete successfully: exit code: 2

2026-01-02 17:18:23.326 ERROR (MainThread) [supervisor.addons.addon] Could not build image for addon 6b4851fc_voltronic: Can't build 6b4851fc/aarch64-addon-voltronic:1.0.1: Docker build failed for 6b4851fc/aarch64-addon-voltronic:1.0.1 (exit code 1). Build output:

#0 building with "default" instance using docker driver

#1 [internal] load build definition from Dockerfile

#1 transferring dockerfile: 1.47kB done

#1 WARN: InvalidDefaultArgInFrom: Default value for ARG ${BUILD_FROM} results in empty or invalid base image name (line 2)

#1 DONE 0.1s

#2 [internal] load metadata for ghcr.io/hassio-addons/debian-base/aarch64:stable

#2 DONE 1.0s

#3 [internal] load .dockerignore

#3 transferring context: 2B done

#3 DONE 0.1s

#4 [1/9] FROM ghcr.io/hassio-addons/debian-base/aarch64:stable@sha256:381cc547d85369bb0b7ff7dcedccd1e149d87789c6fa8e58f1ddd01254db7612

#4 DONE 0.0s

#5 [internal] load build context

#5 transferring context: 1.96kB done

#5 DONE 0.1s

#6 [6/9] RUN rm -rf repo

#6 CACHED

#7 [2/9] RUN apt-get update && apt-get install -y git build-essential cmake jq mosquitto-clients && apt-get clean && rm -rf /var/lib/apt/lists/*

#7 CACHED

#8 [4/9] RUN git clone --filter=blob:none --no-checkout https://github.com/catalinbordan/docker-voltronic-homeassistant.git repo && cd repo && git fetch origin a01e305846c697d985847405909e91ba81289a49 && git checkout a01e305846c697d985847405909e91ba81289a49 && git sparse-checkout init --cone && git sparse-checkout set sources config

#8 CACHED

#9 [5/9] RUN mkdir -p /etc/inverter && cp -r repo/sources/* /opt/ && cp -r repo/config/* /etc/inverter/

#9 CACHED

#10 [7/9] COPY run.sh /run.sh

#10 CACHED

#11 [3/9] WORKDIR /opt

#11 CACHED

#12 [8/9] RUN chmod a+x /run.sh

#12 CACHED

#13 [9/9] RUN cd /opt/inverter-cli && mkdir bin && cmake . && make && mv inverter_poller bin/

#13 0.711 CMake Deprecation Warning at CMakeLists.txt:1 (CMAKE_MINIMUM_REQUIRED):

#13 0.711 Compatibility with CMake < 3.10 will be removed from a future version of

#13 0.711 CMake.

#13 0.711

#13 0.711 Update the VERSION argument <min> value. Or, use the <min>...<max> syntax

#13 0.711 to tell CMake that the project requires at least <min> but has been updated

#13 0.711 to work with policies introduced by <max> or earlier.

#13 0.711

#13 0.711

#13 1.228 -- The C compiler identification is GNU 14.2.0

#13 1.622 -- The CXX compiler identification is GNU 14.2.0

#13 1.652 -- Detecting C compiler ABI info

#13 1.866 -- Detecting C compiler ABI info - done

#13 1.899 -- Check for working C compiler: /usr/bin/cc - skipped

#13 1.900 -- Detecting C compile features

#13 1.902 -- Detecting C compile features - done

#13 1.927 -- Detecting CXX compiler ABI info

#13 2.115 -- Detecting CXX compiler ABI info - done

#13 2.151 -- Check for working CXX compiler: /usr/bin/c++ - skipped

#13 2.152 -- Detecting CXX compile features

#13 2.153 -- Detecting CXX compile features - done

#13 2.167 -- Configuring done (1.5s)

#13 2.172 -- Generating done (0.0s)

#13 2.173 -- Build files have been written to: /opt/inverter-cli

#13 2.257 [ 20%] Building CXX object CMakeFiles/inverter_poller.dir/inputparser.cpp.o

#13 3.085 [ 40%] Building CXX object CMakeFiles/inverter_poller.dir/inverter.cpp.o

#13 3.365 In file included from /opt/inverter-cli/inverter.cpp:6:

#13 3.365 /opt/inverter-cli/inverter.h:16:15: error: field ‘device’ has incomplete type ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’}

#13 3.365 16 | std::string device;

#13 3.365 | ^~~~~~

#13 3.367 In file included from /usr/include/c++/14/iosfwd:41,

#13 3.367 from /usr/include/c++/14/bits/std_thread.h:38,

#13 3.367 from /usr/include/c++/14/thread:45,

#13 3.367 from /opt/inverter-cli/inverter.h:5:

#13 3.367 /usr/include/c++/14/bits/stringfwd.h:72:11: note: declaration of ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}

#13 3.367 72 | class basic_string;

#13 3.367 | ^~~~~~~~~~~~

#13 3.369 /opt/inverter-cli/inverter.cpp:12:34: error: ‘devicename’ has incomplete type

#13 3.369 12 | cInverter::cInverter(std::string devicename) {

#13 3.369 | ~~~~~~~~~~~~^~~~~~~~~~

#13 3.369 /usr/include/c++/14/bits/stringfwd.h:72:11: note: declaration of ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}

#13 3.369 72 | class basic_string;

#13 3.369 | ^~~~~~~~~~~~

#13 3.369 /opt/inverter-cli/inverter.cpp: In member function ‘std::string* cInverter::GetQpigsStatus()’:

#13 3.369 /opt/inverter-cli/inverter.cpp:22:38: error: invalid use of incomplete type ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}

#13 3.369 22 | string *result = new string(status1);

#13 3.369 | ^

#13 3.369 /usr/include/c++/14/bits/stringfwd.h:72:11: note: declaration of ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}

#13 3.369 72 | class basic_string;

#13 3.369 | ^~~~~~~~~~~~

#13 3.370 /opt/inverter-cli/inverter.cpp: In member function ‘std::string* cInverter::GetQpiriStatus()’:

#13 3.370 /opt/inverter-cli/inverter.cpp:29:38: error: invalid use of incomplete type ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}

#13 3.370 29 | string *result = new string(status2);

#13 3.370 | ^

#13 3.370 /usr/include/c++/14/bits/stringfwd.h:72:11: note: declaration of ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}

#13 3.370 72 | class basic_string;

#13 3.370 | ^~~~~~~~~~~~

#13 3.370 /opt/inverter-cli/inverter.cpp: In member function ‘std::string* cInverter::GetWarnings()’:

#13 3.370 /opt/inverter-cli/inverter.cpp:36:39: error: invalid use of incomplete type ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}

#13 3.370 36 | string *result = new string(warnings);

#13 3.370 | ^

#13 3.370 /usr/include/c++/14/bits/stringfwd.h:72:11: note: declaration of ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}

#13 3.370 72 | class basic_string;

#13 3.370 | ^~~~~~~~~~~~

#13 3.371 /opt/inverter-cli/inverter.cpp: In member function ‘bool cInverter::query(const char*)’:

#13 3.371 /opt/inverter-cli/inverter.cpp:154:28: warning: pointer of type ‘void *’ used in arithmetic [-Wpointer-arith]

#13 3.371 154 | n = read(fd, (void*)buf+i, 120 - i);

#13 3.371 | ~~~~~~~~~~^~

#13 3.373 /opt/inverter-cli/inverter.cpp: At global scope:

#13 3.373 /opt/inverter-cli/inverter.cpp:248:41: error: ‘cmd’ has incomplete type

#13 3.373 248 | void cInverter::ExecuteCmd(const string cmd) {

#13 3.373 | ~~~~~~~~~~~~~^~~

#13 3.373 /usr/include/c++/14/bits/stringfwd.h:72:11: note: declaration of ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}

#13 3.373 72 | class basic_string;

#13 3.373 | ^~~~~~~~~~~~

#13 3.425 make[2]: *** [CMakeFiles/inverter_poller.dir/build.make:93: CMakeFiles/inverter_poller.dir/inverter.cpp.o] Error 1

#13 3.425 make[1]: *** [CMakeFiles/Makefile2:87: CMakeFiles/inverter_poller.dir/all] Error 2

#13 3.426 make: *** [Makefile:91: all] Error 2

#13 ERROR: process "/bin/bash -o pipefail -c cd /opt/inverter-cli && mkdir bin && cmake . && make && mv inverter_poller bin/" did not complete successfully: exit code: 2

------

> [9/9] RUN cd /opt/inverter-cli && mkdir bin && cmake . && make && mv inverter_poller bin/:

3.373 /opt/inverter-cli/inverter.cpp: At global scope:

3.373 /opt/inverter-cli/inverter.cpp:248:41: error: ‘cmd’ has incomplete type

3.373 248 | void cInverter::ExecuteCmd(const string cmd) {

3.373 | ~~~~~~~~~~~~~^~~

3.373 /usr/include/c++/14/bits/stringfwd.h:72:11: note: declaration of ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}

3.373 72 | class basic_string;

3.373 | ^~~~~~~~~~~~

3.425 make[2]: *** [CMakeFiles/inverter_poller.dir/build.make:93: CMakeFiles/inverter_poller.dir/inverter.cpp.o] Error 1

3.425 make[1]: *** [CMakeFiles/Makefile2:87: CMakeFiles/inverter_poller.dir/all] Error 2

3.426 make: *** [Makefile:91: all] Error 2

------

1 warning found (use docker --debug to expand):

- InvalidDefaultArgInFrom: Default value for ARG ${BUILD_FROM} results in empty or invalid base image name (line 2)

Dockerfile:41

--------------------

40 | # Build the inverter CLI

41 | >>> RUN cd /opt/inverter-cli && \

42 | >>> mkdir bin && \

43 | >>> cmake . && \

44 | >>> make && \

45 | >>> mv inverter_poller bin/

46 |

--------------------

ERROR: failed to build: failed to solve: process "/bin/bash -o pipefail -c cd /opt/inverter-cli && mkdir bin && cmake . && make && mv inverter_poller bin/" did not complete successfully: exit code: 2"